### PR TITLE
Modernize the advanced table examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nord Advanced Table Examples
 
-This repo includes examples in both Vue and React showing how to combine Tanstack table and AG Grid with Nord Design System, in order to build a table with sorting, resizable columns, draggable and re-orderable columns, plus sticky/pinned columns.
+This repo includes examples in both Vue and React showing how to combine TanStack Table and AG Grid with Nord Design System, in order to build a table with sorting, resizable columns, draggable and re-orderable columns, plus sticky/pinned columns.
 
 ## Learn More
 
@@ -16,4 +16,4 @@ If you experience any issues while getting started with any of Nord’s tools, p
 
 ## Copyright
 
-Copyright © 2022 Nordhealth Ltd.
+Copyright © 2025 Nordhealth Ltd.

--- a/nord-react-ag-grid/package.json
+++ b/nord-react-ag-grid/package.json
@@ -14,9 +14,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@nordhealth/components": "latest",
     "@nordhealth/ag-theme-nord": "latest",
     "@nordhealth/css": "latest",
-    "@nordhealth/react": "latest",
     "ag-grid-community": "33.3.2",
     "ag-grid-react": "33.3.2",
     "react": "^19.1.0",

--- a/nord-react-ag-grid/package.json
+++ b/nord-react-ag-grid/package.json
@@ -17,16 +17,16 @@
     "@nordhealth/ag-theme-nord": "latest",
     "@nordhealth/css": "latest",
     "@nordhealth/react": "latest",
-    "ag-grid-community": "28.1.1",
-    "ag-grid-react": "28.1.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "ag-grid-community": "33.3.2",
+    "ag-grid-react": "33.3.2",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "@vitejs/plugin-react": "^2.1.0",
-    "typescript": "^4.6.3",
-    "vite": "^3.1.4"
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
   }
 }

--- a/nord-react-ag-grid/src/App.tsx
+++ b/nord-react-ag-grid/src/App.tsx
@@ -1,11 +1,10 @@
-import { Card } from "@nordhealth/react";
 import { PayoutsTable } from "./PayoutsTable";
 
 export default function App() {
   return (
-    <Card padding="none">
+    <nord-card padding="none">
       <h2 slot="header">Payouts</h2>
       <PayoutsTable />
-    </Card>
+    </nord-card>
   );
 }

--- a/nord-react-ag-grid/src/DataTable/CustomHeader.tsx
+++ b/nord-react-ag-grid/src/DataTable/CustomHeader.tsx
@@ -12,6 +12,7 @@ export function CustomHeader({
   column,
   setSort,
   displayName,
+  api,
 }: IHeaderParams) {
   const textAlign =
     column.getColDef().type === "rightAligned" ? "end" : undefined;
@@ -23,6 +24,7 @@ export function CustomHeader({
         if (enableSorting) {
           const order = sortOrderMap[column.getSort() || "default"];
           setSort(order, event.shiftKey);
+          api.refreshHeader();
         }
       }}
     >

--- a/nord-react-ag-grid/src/DataTable/DataTable.tsx
+++ b/nord-react-ag-grid/src/DataTable/DataTable.tsx
@@ -1,5 +1,11 @@
 import { AgGridReact } from "ag-grid-react";
-import { ColDef, GridReadyEvent } from "ag-grid-community";
+import {
+  ColDef,
+  GridReadyEvent,
+  ModuleRegistry,
+  AllCommunityModule,
+  provideGlobalGridOptions,
+} from "ag-grid-community";
 import "ag-grid-community/styles/ag-grid.css";
 import "@nordhealth/ag-theme-nord";
 import "./DataTable.css";
@@ -10,9 +16,15 @@ const components = {
   agColumnHeader: CustomHeader,
 };
 
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+provideGlobalGridOptions({
+  theme: "legacy",
+});
+
 const onGridReady = (params: GridReadyEvent) => {
   params.api.sizeColumnsToFit();
-  params.api.setDomLayout("autoHeight");
+  params.api.setGridOption("domLayout", "autoHeight");
 };
 
 export function DataTable<TData>({

--- a/nord-react-ag-grid/src/DataTable/SortButton.tsx
+++ b/nord-react-ag-grid/src/DataTable/SortButton.tsx
@@ -1,5 +1,4 @@
 import "./SortButton.css";
-import { Icon } from "@nordhealth/react";
 import { Column } from "ag-grid-community";
 
 const sortIconMap = {
@@ -11,12 +10,12 @@ const sortIconMap = {
 export function SortButton({ sort }: { sort: ReturnType<Column["getSort"]> }) {
   return (
     <button className="sort-btn">
-      <Icon
+      <nord-icon
         size="xs"
         color="currentColor"
         name={sortIconMap[sort || "default"]}
         label="Press to sort"
-      ></Icon>
+      ></nord-icon>
     </button>
   );
 }

--- a/nord-react-ag-grid/src/PayoutsTable.tsx
+++ b/nord-react-ag-grid/src/PayoutsTable.tsx
@@ -1,11 +1,3 @@
-import {
-  Badge,
-  Dropdown,
-  Button,
-  Icon,
-  DropdownGroup,
-  DropdownItem,
-} from "@nordhealth/react";
 import { ColDef } from "ag-grid-community";
 
 import { Data, data } from "./data.js";
@@ -29,39 +21,44 @@ const statusMap = {
 } as const;
 
 const StatusRenderer = ({ value }: { value: Data["status"] }) => (
-  <Badge style={{ textTransform: "capitalize" }} variant={statusMap[value]}>
+  <nord-badge
+    style={{ textTransform: "capitalize" }}
+    variant={statusMap[value]}
+  >
     {value}
-  </Badge>
+  </nord-badge>
 );
 
 const ActionDropdown = () => (
-  <Dropdown
+  <nord-dropdown
     size="s"
     position="block-end"
     align="end"
     style={{ display: "inline-block", marginBlock: -10 }}
   >
-    <Button slot="toggle" aria-describedby="tooltip" size="s">
-      <Icon
+    <nord-button slot="toggle" aria-describedby="tooltip" size="s">
+      <nord-icon
         name="interface-menu-small"
         color="var(--n-color-icon)"
         label="Open menu"
         size="s"
-      ></Icon>
-    </Button>
-    <DropdownGroup>
-      <DropdownItem href="#">View payment details</DropdownItem>
-      <DropdownItem>Open in new tab</DropdownItem>
-      <DropdownItem>Copy link</DropdownItem>
-    </DropdownGroup>
-    <DropdownGroup>
-      <DropdownItem data-action="refund">Refund payment</DropdownItem>
-      <DropdownItem data-action="delete">
+      ></nord-icon>
+    </nord-button>
+    <nord-dropdown-group>
+      <nord-dropdown-item href="#">View payment details</nord-dropdown-item>
+      <nord-dropdown-item>Open in new tab</nord-dropdown-item>
+      <nord-dropdown-item>Copy link</nord-dropdown-item>
+    </nord-dropdown-group>
+    <nord-dropdown-group>
+      <nord-dropdown-item data-action="refund">
+        Refund payment
+      </nord-dropdown-item>
+      <nord-dropdown-item data-action="delete">
         <span>Delete</span>
-        <Icon slot="end" name="interface-delete" size="s"></Icon>
-      </DropdownItem>
-    </DropdownGroup>
-  </Dropdown>
+        <nord-icon slot="end" name="interface-delete" size="s"></nord-icon>
+      </nord-dropdown-item>
+    </nord-dropdown-group>
+  </nord-dropdown>
 );
 
 const columns: ColDef<Data>[] = [

--- a/nord-react-ag-grid/src/main.tsx
+++ b/nord-react-ag-grid/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@nordhealth/css";
+import "@nordhealth/components";
 
 import App from "./App";
 

--- a/nord-react-ag-grid/tsconfig.json
+++ b/nord-react-ag-grid/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["@nordhealth/components/lib/react.d.ts"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/nord-react-tanstack-table/package.json
+++ b/nord-react-tanstack-table/package.json
@@ -16,15 +16,15 @@
   "dependencies": {
     "@nordhealth/css": "latest",
     "@nordhealth/react": "latest",
-    "@tanstack/react-table": "8.5.13",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "@tanstack/react-table": "8.21.3",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "@vitejs/plugin-react": "^2.1.0",
-    "typescript": "^4.6.3",
-    "vite": "^3.1.4"
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
   }
 }

--- a/nord-react-tanstack-table/package.json
+++ b/nord-react-tanstack-table/package.json
@@ -14,8 +14,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@nordhealth/components": "latest",
     "@nordhealth/css": "latest",
-    "@nordhealth/react": "latest",
     "@tanstack/react-table": "8.21.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/nord-react-tanstack-table/src/App.tsx
+++ b/nord-react-tanstack-table/src/App.tsx
@@ -1,11 +1,10 @@
-import { Card } from "@nordhealth/react";
 import { PayoutsTable } from "./PayoutsTable";
 
 export default function App() {
   return (
-    <Card padding="none">
+    <nord-card padding="none">
       <h2 slot="header">Payouts</h2>
       <PayoutsTable />
-    </Card>
+    </nord-card>
   );
 }

--- a/nord-react-tanstack-table/src/DataTable/DataTable.tsx
+++ b/nord-react-tanstack-table/src/DataTable/DataTable.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { Table } from "@nordhealth/react";
 import { flexRender, Table as TanstackTable } from "@tanstack/react-table";
 
 import "./DataTable.css";
@@ -28,7 +27,7 @@ export function DataTable<TData>({ table }: { table: TanstackTable<TData> }) {
   usePreventSelection(isResizing);
 
   return (
-    <Table className={isResizing ? "is-resizing" : ""}>
+    <nord-table className={isResizing ? "is-resizing" : ""}>
       <table>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
@@ -92,6 +91,6 @@ export function DataTable<TData>({ table }: { table: TanstackTable<TData> }) {
           ))}
         </tbody>
       </table>
-    </Table>
+    </nord-table>
   );
 }

--- a/nord-react-tanstack-table/src/DataTable/SortButton.tsx
+++ b/nord-react-tanstack-table/src/DataTable/SortButton.tsx
@@ -1,4 +1,3 @@
-import { Icon } from "@nordhealth/react";
 import { Header } from "@tanstack/react-table";
 import "./SortButton.css";
 
@@ -15,12 +14,12 @@ export function SortButton<TData, TValue>({
 }) {
   return (
     <button className="sort-btn">
-      <Icon
+      <nord-icon
         size="xs"
         color="currentColor"
         name={sortIconMap[header.column.getIsSorted() || "default"]}
         label="Press to sort"
-      ></Icon>
+      ></nord-icon>
     </button>
   );
 }

--- a/nord-react-tanstack-table/src/PayoutsTable.tsx
+++ b/nord-react-tanstack-table/src/PayoutsTable.tsx
@@ -1,12 +1,4 @@
 import {
-  Badge,
-  Dropdown,
-  Button,
-  Icon,
-  DropdownGroup,
-  DropdownItem,
-} from "@nordhealth/react";
-import {
   createColumnHelper,
   useReactTable,
   getCoreRowModel,
@@ -35,33 +27,35 @@ const currencyFormatter = new Intl.NumberFormat("fi-FI", {
 
 function ActionDropdown() {
   return (
-    <Dropdown
+    <nord-dropdown
       size="s"
       position="block-end"
       align="end"
       style={{ display: "inline-block", marginBlock: -10 }}
     >
-      <Button slot="toggle" aria-describedby="tooltip" size="s">
-        <Icon
+      <nord-button slot="toggle" aria-describedby="tooltip" size="s">
+        <nord-icon
           name="interface-menu-small"
           color="var(--n-color-icon)"
           label="Open menu"
           size="s"
-        ></Icon>
-      </Button>
-      <DropdownGroup>
-        <DropdownItem href="#">View payment details</DropdownItem>
-        <DropdownItem>Open in new tab</DropdownItem>
-        <DropdownItem>Copy link</DropdownItem>
-      </DropdownGroup>
-      <DropdownGroup>
-        <DropdownItem data-action="refund">Refund payment</DropdownItem>
-        <DropdownItem data-action="delete">
+        ></nord-icon>
+      </nord-button>
+      <nord-dropdown-group>
+        <nord-dropdown-item href="#">View payment details</nord-dropdown-item>
+        <nord-dropdown-item>Open in new tab</nord-dropdown-item>
+        <nord-dropdown-item>Copy link</nord-dropdown-item>
+      </nord-dropdown-group>
+      <nord-dropdown-group>
+        <nord-dropdown-item data-action="refund">
+          Refund payment
+        </nord-dropdown-item>
+        <nord-dropdown-item data-action="delete">
           <span>Delete</span>
-          <Icon slot="end" name="interface-delete" size="s"></Icon>
-        </DropdownItem>
-      </DropdownGroup>
-    </Dropdown>
+          <nord-icon slot="end" name="interface-delete" size="s"></nord-icon>
+        </nord-dropdown-item>
+      </nord-dropdown-group>
+    </nord-dropdown>
   );
 }
 
@@ -83,7 +77,9 @@ const columns = [
     size: 90,
     minSize: 90,
     cell: (props) => (
-      <Badge variant={statusMap[props.getValue()]}>{props.getValue()}</Badge>
+      <nord-badge variant={statusMap[props.getValue()]}>
+        {props.getValue()}
+      </nord-badge>
     ),
     meta: {
       style: {

--- a/nord-react-tanstack-table/src/main.tsx
+++ b/nord-react-tanstack-table/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@nordhealth/css";
+import "@nordhealth/components";
 
 import App from "./App";
 

--- a/nord-react-tanstack-table/tsconfig.json
+++ b/nord-react-tanstack-table/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["@nordhealth/components/lib/react.d.ts"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/nord-vue-ag-grid/package.json
+++ b/nord-vue-ag-grid/package.json
@@ -18,14 +18,14 @@
     "@nordhealth/ag-theme-nord": "latest",
     "@nordhealth/components": "latest",
     "@nordhealth/css": "latest",
-    "ag-grid-community": "^28.1.1",
-    "ag-grid-vue3": "^28.1.1",
+    "ag-grid-community": "^33.3.2",
+    "ag-grid-vue3": "^33.3.2",
     "vue": "^3.2.37"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^3.1.0",
-    "typescript": "^4.6.4",
-    "vite": "^3.1.4",
-    "vue-tsc": "^0.40.4"
+    "@vitejs/plugin-vue": "^5.2.4",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5",
+    "vue-tsc": "^2.2.10"
   }
 }

--- a/nord-vue-ag-grid/src/components/DataTable/DataTable.vue
+++ b/nord-vue-ag-grid/src/components/DataTable/DataTable.vue
@@ -2,7 +2,13 @@
 import "ag-grid-community/styles/ag-grid.css";
 import "@nordhealth/ag-theme-nord";
 
-import { GridOptions, GridReadyEvent } from "ag-grid-community";
+import {
+  GridOptions,
+  GridReadyEvent,
+  ModuleRegistry,
+  AllCommunityModule,
+  provideGlobalGridOptions,
+} from "ag-grid-community";
 import { AgGridVue } from "ag-grid-vue3";
 import CustomHeader from "./CustomHeader.vue";
 
@@ -13,9 +19,15 @@ const { columns, defaultColumn, data, components } = defineProps<{
   data: any;
 }>();
 
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+provideGlobalGridOptions({
+  theme: "legacy",
+});
+
 const onGridReady = (params: GridReadyEvent) => {
   params.api.sizeColumnsToFit();
-  params.api.setDomLayout("autoHeight");
+  params.api.setGridOption("domLayout", "autoHeight");
 };
 </script>
 

--- a/nord-vue-ag-grid/tsconfig.json
+++ b/nord-vue-ag-grid/tsconfig.json
@@ -11,7 +11,8 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["ESNext", "DOM"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["@nordhealth/components/lib/vue.d.ts"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/nord-vue-tanstack-table/package.json
+++ b/nord-vue-tanstack-table/package.json
@@ -17,13 +17,13 @@
   "dependencies": {
     "@nordhealth/components": "latest",
     "@nordhealth/css": "latest",
-    "@tanstack/vue-table": "^8.5.11",
-    "vue": "^3.2.37"
+    "@tanstack/vue-table": "^8.21.3",
+    "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^3.1.0",
-    "typescript": "^4.6.4",
-    "vite": "^3.1.4",
-    "vue-tsc": "^0.40.4"
+    "@vitejs/plugin-vue": "^5.2.4",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5",
+    "vue-tsc": "^2.2.10"
   }
 }

--- a/nord-vue-tanstack-table/tsconfig.json
+++ b/nord-vue-tanstack-table/tsconfig.json
@@ -11,7 +11,8 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["ESNext", "DOM"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["@nordhealth/components/lib/vue.d.ts"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
* Updated the dependencies to the latest.
* Removed the React wrappers.
* Added React and Vue types.
* AG Grid has a [new Theming API](https://www.ag-grid.com/javascript-data-grid/theming-migration/), but I've used the legacy themes setup of AG Grid for now, since it will require significant changes to the `@nordhealth/ag-theme-nord` package (will add a PR to the Nord docs to mention this in the Table docs).